### PR TITLE
Update bump seed canonicalization check

### DIFF
--- a/api/builtin_templates/missing_bump_seed_canonicalization.yaml
+++ b/api/builtin_templates/missing_bump_seed_canonicalization.yaml
@@ -1,14 +1,16 @@
-version: 0.1.0
+version: 0.1.1
 author: forefy
 name: Missing Bump Seed Canonicalization
 severity: Medium
 certainty: Low
-description: If a program is deriving a bump seed for a Program Derived Address (PDA) without ensuring its uniqueness, it could lead to collisions or unexpected insecure logical occurrences.
+description: If a program is deriving a bump seed for a Program Derived Address (PDA) without ensuring its uniqueness, it could lead to collisions or unexpected insecure logical occurrences. Check for usage of program_id which is not part of Pubkey::find_program_address and there is a usage of "bump"
 rule: |
   for source, nodes in ast:
       try:
           program_id_usages = nodes.find_member_accesses("program_id").exit_on_none()
           nodes.find_chained_calls("Pubkey", "find_program_address").exit_on_value()
+          nodes.find_member_accesses("bump").exit_on_none()
+          nodes.find_chained_calls("Pubkey", "create_program_address").exit_on_none()
           print(program_id_usages.first().to_result())
       except:
           continue


### PR DESCRIPTION
It is a common pattern when not using anchor especially to have this entrypoint in the code

pub fn process_instruction(
    program_id: &Pubkey,
    accounts: &[AccountInfo],
    instruction_data: &[u8],
) -> ProgramResult {


which raises a false positive on this template.
Change the template to more closely check for the conditions that it is worried about. It is concerned with the possibility of an attacker providing a non-canonical bump that the program uses and gets a different PDA than expected. It is safe then to check for the word bump and for create_program_address because those are part of the case that is of concern. Note that someone could use a word other than "bump", but similarly they could also use something other than "program_id".

Tested that this still gets caught
https://github.com/forefy/sealevel-attacks/blob/master/programs/7-bump-seed-canonicalization/insecure/src/lib.rs#L11